### PR TITLE
Add retrieval relevance floor + RAGAS faithfulness benchmark tier

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -56,9 +56,10 @@ jobs:
           acrUsername: ${{ secrets.REGISTRY_USERNAME }}
           acrPassword: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Disable scale to zero
+      - name: Configure app (replicas + retrieval relevance floor)
         run: |
           az containerapp update \
             --name ragobs-api \
             --resource-group gpu-store-rg \
-            --min-replicas 1
+            --min-replicas 1 \
+            --set-env-vars FLASHCARD_MAX_RETRIEVAL_DISTANCE=0.65

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Gate CI only on the free deterministic metrics (`dev` profile on every PR); run 
 | `EMBEDDING_BACKEND` | `ollama` in dev / `openrouter` in prod | `ollama` \| `openrouter` \| `sentence_transformers` |
 | `FLASHCARD_LLM_BACKEND` | follows `ENV` | Override LLM backend independently of `ENV`: `openrouter` \| `ollama` (used by benchmarks) |
 | `FLASHCARD_LLM_TEMPERATURE` | `0.2` | Generation sampling temperature; benchmark profiles pin it to `0` |
+| `FLASHCARD_MAX_RETRIEVAL_DISTANCE` | `0` (disabled) | Cosine-distance floor: drop retrieved chunks farther than this from the query, so focused queries stay on-topic and irrelevant queries return no cards. Tune with `benchmarks/sweep_distance.py` before enabling |
 | `OLLAMA_EMBED_MODEL` | `nomic-embed-text` | Local Ollama embedding model |
 | `OPENROUTER_EMBED_MODEL` | `openai/text-embedding-3-small` | Production OpenRouter embedding model |
 | `OPENROUTER_MODEL` | `deepseek/deepseek-chat-v3-0324` | OpenRouter LLM model |

--- a/backend/benchmarks/README.md
+++ b/backend/benchmarks/README.md
@@ -17,7 +17,8 @@ BM25 + pgvector retrieval without writing decks to the DB.
 | `runner.py` | Runs each case → `results/<ts>/raw.jsonl` |
 | `scorers/retrieval.py` | Recall@k, MRR, precision (deterministic, no LLM) |
 | `scorers/format.py` | Prompt-contract checks (deterministic, no LLM) |
-| `report.py` | Aggregates → scorecard + `summary.json`, CI gate |
+| `report.py` | Aggregates → scorecard + `summary.json`, CI gate; `--faithfulness` adds the RAGAS tier + `faithfulness.json` |
+| `sweep_distance.py` | Tune `FLASHCARD_MAX_RETRIEVAL_DISTANCE` (relevance floor) from query↔chunk distances — retrieval only, no LLM |
 | `run_with_neon_branch.sh` | Branch prod → run → drop branch (for the `prod` profile) |
 
 ## Quick start (dev)

--- a/backend/benchmarks/dataset.jsonl
+++ b/backend/benchmarks/dataset.jsonl
@@ -16,4 +16,4 @@
 {"id": "cap-consistency-availability", "prompt": "what tradeoff does the CAP theorem force during a network partition", "k": 8, "relevant_files": ["cap-theorem.md"]}
 {"id": "http-401-vs-403", "prompt": "what is the difference between http 401 and 403 status codes", "k": 6, "relevant_files": ["http-status-codes.md"], "flashcard_amount": "small"}
 {"id": "caching-cache-aside", "prompt": "show the cache-aside read pattern in python", "k": 8, "relevant_files": ["caching-strategies.md"], "expect_code_card": true}
-{"id": "out-of-corpus", "prompt": "what is the capital of France", "k": 8, "relevant_files": []}
+{"id": "out-of-corpus", "prompt": "what is the capital of France", "k": 8, "relevant_files": [], "expect_no_cards": true}

--- a/backend/benchmarks/report.py
+++ b/backend/benchmarks/report.py
@@ -135,10 +135,27 @@ def main() -> None:
             print("\n[faithfulness] running RAGAS judge (paid)...")
             judge = faithfulness_scorer._judge_llm()
             faiths = []
+            detail = []
             for rec in records:
                 res = faithfulness_scorer.score(rec, llm=judge)
-                if res is not None:
-                    faiths.append(res["faithfulness_mean"])
+                if res is None:
+                    continue
+                faiths.append(res["faithfulness_mean"])
+                cid = rec["case"].get("id", rec["case"]["prompt"][:30])
+                detail.append(
+                    {
+                        "id": cid,
+                        "faithfulness_mean": res["faithfulness_mean"],
+                        "per_card": res["per_card"],
+                    }
+                )
+            if detail:
+                # Lowest-grounded cases first — these are what to look at.
+                detail.sort(key=lambda d: d["faithfulness_mean"])
+                (run_dir / "faithfulness.json").write_text(json.dumps(detail, indent=2))
+                print("  per-case (low to high):")
+                for d in detail:
+                    print(f"    {d['faithfulness_mean']:.2f}  {d['id']}")
             if faiths:
                 summary["faithfulness_mean"] = _mean(faiths)
                 summary["faithfulness_n_scored"] = len(faiths)

--- a/backend/benchmarks/scorers/faithfulness.py
+++ b/backend/benchmarks/scorers/faithfulness.py
@@ -62,6 +62,15 @@ def score(record: dict, llm=None) -> dict | None:
     from ragas.dataset_schema import EvaluationDataset, SingleTurnSample
     from ragas.metrics import Faithfulness
 
+    case = record.get("case") or {}
+    relevant = case.get("relevant_files")
+    if case.get("expect_no_cards") or (
+        isinstance(relevant, list) and len(relevant) == 0
+    ):
+        # Out-of-corpus case: there's no correct grounded answer, so faithfulness
+        # is meaningless here — refusal is scored by format.py instead.
+        return None
+
     cards = record.get("flashcards")
     contexts = [
         s["content"]

--- a/backend/benchmarks/scorers/format.py
+++ b/backend/benchmarks/scorers/format.py
@@ -26,6 +26,14 @@ def _is_parse_fallback(cards: list[dict] | None) -> bool:
     )
 
 
+def _expects_no_cards(case: dict) -> bool:
+    """Negative case: the right behaviour is to refuse (produce no cards)."""
+    relevant = case.get("relevant_files")
+    return bool(case.get("expect_no_cards")) or (
+        isinstance(relevant, list) and len(relevant) == 0
+    )
+
+
 def score(record: dict) -> dict:
     case = record["case"]
     cards = record.get("flashcards")
@@ -33,6 +41,14 @@ def score(record: dict) -> dict:
     valid_tags = {s.get("tag") for s in sources}
 
     checks: dict[str, bool] = {}
+
+    # Out-of-corpus query: passing means refusing (no cards), not hallucinating
+    # off-topic ones. This requires the retrieval relevance floor to be enabled
+    # (FLASHCARD_MAX_RETRIEVAL_DISTANCE); with it off, the model invents cards and
+    # this correctly fails.
+    if _expects_no_cards(case):
+        checks["refused"] = not cards and record.get("error") is None
+        return {"checks": checks, "passed": all(checks.values())}
 
     # Generation produced parseable cards (didn't error, didn't hit the fallback).
     checks["produced_cards"] = bool(cards) and record.get("error") is None

--- a/backend/benchmarks/sweep_distance.py
+++ b/backend/benchmarks/sweep_distance.py
@@ -1,0 +1,119 @@
+"""Pick FLASHCARD_MAX_RETRIEVAL_DISTANCE without paying for generation.
+
+The relevance floor (services.flashcards_service.FLASHCARD_MAX_RETRIEVAL_DISTANCE)
+drops retrieved chunks whose cosine distance (pgvector `<=>`) to the query is too
+large. This script measures those distances directly — for each labeled case it
+embeds the prompt and computes the distance to every chunk in the eval session,
+split by whether the chunk's file is in the case's ``relevant_files`` — so you can
+choose a cutoff that keeps the relevant chunks and drops the rest. It does NOT
+call the LLM, so it's cheap to run repeatedly.
+
+What to look for:
+  - ``rel_kept``  : relevant chunks surviving — want this to stay high.
+  - ``off_kept``  : off-topic chunks surviving — want this low.
+  - ``ooc_kept``  : chunks surviving for the out-of-corpus case — want 0 so it
+                    returns no cards.
+A good threshold is the smallest one that keeps rel_kept high while pushing
+off_kept and ooc_kept down.
+
+Usage (from backend/, with DATABASE_URL pointing at the seeded eval DB):
+  python -m benchmarks.sweep_distance --profile prod
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from benchmarks.config import EVAL_SESSION_ID, apply_profile
+
+DATASET = Path(__file__).parent / "dataset.jsonl"
+THRESHOLDS = [0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.90, 1.00]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", default="prod")
+    args = parser.parse_args()
+    apply_profile(args.profile)
+
+    # Imported after apply_profile so backend constants pick up the profile env.
+    from sqlalchemy import text as sql_text
+
+    from db.models import Sessions
+    from db.session import SessionLocal
+    from services.embedding_service import embed_query_sync
+    from services.flashcards_service import (
+        DEFAULT_EMBEDDING_PROFILE,
+        effective_profile,
+        get_embedding_table,
+        normalize_embedding_profile,
+    )
+
+    db = SessionLocal()
+    session = db.get(Sessions, EVAL_SESSION_ID)
+    if session is None:
+        raise SystemExit("Eval session not found — run `benchmarks.seed` first.")
+    profile = normalize_embedding_profile(session.embedding_profile)
+    table = get_embedding_table(effective_profile(profile or DEFAULT_EMBEDDING_PROFILE))
+
+    cases = [
+        json.loads(line)
+        for line in DATASET.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+
+    # Per-case distance lists: relevant-file chunks vs everything else.
+    per_case: list[tuple[str, bool, list[float], list[float]]] = []
+    for case in cases:
+        prompt = case.get("prompt")
+        if not prompt:
+            continue
+        relevant = set(case.get("relevant_files") or [])
+        qvec = embed_query_sync(prompt, profile=profile)
+        rows = db.execute(
+            sql_text(
+                "SELECT filename, (embedding <=> (:qvec)::vector) AS distance "
+                f"FROM {table} WHERE session_id = :sid"
+            ),
+            {"qvec": qvec.tolist(), "sid": EVAL_SESSION_ID},
+        ).fetchall()
+        rel = sorted(float(r.distance) for r in rows if r.filename in relevant)
+        off = sorted(float(r.distance) for r in rows if r.filename not in relevant)
+        per_case.append((case.get("id", prompt[:20]), bool(relevant), rel, off))
+
+    db.close()
+
+    # Per-case nearest distances — shows the gap between relevant and off-topic.
+    print("nearest distances per case (lower = more similar):")
+    print(f"  {'case':28} {'rel_min':>7} {'rel_med':>7} {'off_min':>7}")
+    for cid, has_rel, rel, off in per_case:
+        rel_min = f"{rel[0]:.3f}" if rel else "—"
+        rel_med = f"{rel[len(rel) // 2]:.3f}" if rel else "—"
+        off_min = f"{off[0]:.3f}" if off else "—"
+        tag = "" if has_rel else "  (out-of-corpus)"
+        print(f"  {cid:28} {rel_min:>7} {rel_med:>7} {off_min:>7}{tag}")
+
+    # Threshold sweep, aggregated across labeled cases.
+    labeled = [c for c in per_case if c[1]]
+    ooc = [c for c in per_case if not c[1]]
+    print("\nthreshold sweep (summed over cases):")
+    print(f"  {'thresh':>6} {'rel_kept':>9} {'off_kept':>9} {'ooc_kept':>9}")
+    for t in THRESHOLDS:
+        rel_kept = sum(sum(1 for d in rel if d <= t) for _, _, rel, _ in labeled)
+        off_kept = sum(sum(1 for d in off if d <= t) for _, _, _, off in labeled)
+        ooc_kept = sum(
+            sum(1 for d in rel + off if d <= t) for _, _, rel, off in ooc
+        )
+        print(f"  {t:>6.2f} {rel_kept:>9} {off_kept:>9} {ooc_kept:>9}")
+
+    print(
+        "\nPick the smallest threshold that keeps rel_kept high while off_kept and "
+        "ooc_kept drop, then set FLASHCARD_MAX_RETRIEVAL_DISTANCE and run the "
+        "benchmark to confirm."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/prompt.py
+++ b/backend/prompt.py
@@ -34,8 +34,9 @@ Source: 2
 Keep non-code answers under 50 words.
 Ground every answer strictly in its cited Source chunk: state only facts, terms,
 numbers, and relationships that appear in that context. Do not add outside
-knowledge, do not generalize beyond the text, and do not combine unrelated chunks
-into one answer. If the context does not support a full card, write fewer cards.
+knowledge, do not generalize beyond the text, and do not merge unrelated chunks
+into one card. Still return exactly {n_flashcards} cards, and always include the
+required code card (described above) whenever the context contains a code block.
 
 Context:
 {context}

--- a/backend/services/flashcards_service.py
+++ b/backend/services/flashcards_service.py
@@ -59,6 +59,14 @@ FLASHCARD_MIN_CODE_CARDS = 1
 FLASHCARD_MAX_CODE_BLOCKS_IN_CONTEXT = 3
 HYBRID_VECTOR_WEIGHT = 0.6
 HYBRID_KEYWORD_WEIGHT = 0.4
+# Post-retrieval relevance floor: drop retrieved chunks whose cosine distance
+# (pgvector `<=>`, 0=identical … 2=opposite) to the query exceeds this, so a
+# focused query stops dragging in off-topic chunks and a query matching nothing
+# returns no cards at all. 0 / unset = disabled (no behaviour change). Tune
+# against the benchmark before raising in prod.
+FLASHCARD_MAX_RETRIEVAL_DISTANCE = float(
+    os.getenv("FLASHCARD_MAX_RETRIEVAL_DISTANCE", "0") or 0
+)
 FLASHCARD_LLM_TIMEOUT_SECONDS = int(os.getenv("FLASHCARD_LLM_TIMEOUT_SECONDS", "90"))
 FLASHCARD_LLM_MODEL = os.getenv("FLASHCARD_LLM_MODEL", "llama3.1")
 FLASHCARD_LLM_KEEP_ALIVE = os.getenv("FLASHCARD_LLM_KEEP_ALIVE", "30m")
@@ -129,6 +137,34 @@ def _fetch_embedding_rows(
         base_query += "LIMIT :k"
         params["k"] = limit
     return db.execute(sql_text(base_query), params).fetchall()
+
+
+def _relevance_distances(
+    db: Session,
+    session_id: UUID | None,
+    file_ids: list[int] | None,
+    *,
+    table_name: str,
+    qvec: object,
+    keys: list[tuple[str, int]],
+) -> dict[tuple[str, int], float]:
+    """Cosine distance from the query to each (filename, chunk_index) in ``keys``.
+
+    One pass over the chunks of the already-retrieved filenames; missing keys are
+    simply absent from the result (callers treat that as "drop it").
+    """
+    if not keys:
+        return {}
+    clauses, params = _build_embedding_filters(session_id, file_ids)
+    clauses.append("filename = ANY(:fns)")
+    params["fns"] = sorted({fn for fn, _ in keys})
+    params["qvec"] = qvec.tolist()
+    query = (
+        "SELECT filename, chunk_index, (embedding <=> (:qvec)::vector) AS distance "
+        f"FROM {table_name} WHERE " + " AND ".join(clauses)
+    )
+    rows = db.execute(sql_text(query), params).fetchall()
+    return {(row.filename, row.chunk_index): float(row.distance) for row in rows}
 
 
 def _rows_to_documents(rows) -> list[Document]:
@@ -906,6 +942,35 @@ async def generate_flashcards(
         deduped_items = deduped_items[:effective_k]
         seen_keys = {(filename, chunk_index) for filename, chunk_index, _ in deduped_items}
     row_items = deduped_items
+
+    # Relevance floor: drop chunks whose cosine distance to the query exceeds the
+    # threshold. Keeps focused queries on-topic, and lets an off-topic query
+    # ("capital of France") fall through to an empty context → no cards. Applied
+    # before code recovery so code-intent queries can still get a code chunk back.
+    if prompt and FLASHCARD_MAX_RETRIEVAL_DISTANCE > 0 and row_items:
+        qvec = await embed_query(prompt, profile=embedding_profile)
+        distances = _relevance_distances(
+            db,
+            session_id,
+            file_ids,
+            table_name=embedding_table,
+            qvec=qvec,
+            keys=[(fn, ci) for fn, ci, _ in row_items],
+        )
+        kept = [
+            item
+            for item in row_items
+            if distances.get((item[0], item[1]), float("inf"))
+            <= FLASHCARD_MAX_RETRIEVAL_DISTANCE
+        ]
+        dropped = len(row_items) - len(kept)
+        if dropped:
+            print(
+                f"[Relevance Floor] dropped {dropped}/{len(row_items)} chunks "
+                f"beyond distance {FLASHCARD_MAX_RETRIEVAL_DISTANCE}"
+            )
+        row_items = kept
+        seen_keys = {(fn, ci) for fn, ci, _ in row_items}
 
     code_items = [item for item in row_items if is_code_block_content(item[2])]
     # Code-intent queries ("...in python", "implement...") should always yield a


### PR DESCRIPTION
## Summary

Retrieval was filling `k` slots regardless of relevance — flooding focused queries with off-topic chunks (a BST query was literally half Bayes) and never refusing out-of-corpus queries. Generation had also silently stopped emitting code cards because heading-prefixed code chunks broke code detection.

### Production
- **Fix code-card detection**: `is_code_block_content` + the code-recovery query now handle heading-prefixed code chunks; forced code injection is gated to code-intent queries only.
- **Relevance floor** (`FLASHCARD_MAX_RETRIEVAL_DISTANCE`, env-gated, default off): drops retrieved chunks beyond a cosine-distance cutoff so focused queries stay on-topic and unmatched queries return no cards. Set to `0.65` in the deploy workflow.
- **Prompt grounding** strengthened without suppressing the required code card.

### Benchmark
- **RAGAS faithfulness tier** (`report --faithfulness`): prod-only, non-gating, OpenRouter judge, optional deps kept out of the prod image; persists per-card scores to `faithfulness.json`.
- **`sweep_distance.py`**: tunes the floor from query/chunk distances, no LLM spend.
- **out-of-corpus** is now a refusal test (format) and skipped in faithfulness.

## Results (tuned at distance 0.65)

| Metric | Before | After |
|--------|--------|-------|
| faithfulness_mean | 0.77 | **0.95** |
| mrr | 0.75 | **1.00** |
| format_pass_rate | 0.90 | **1.00** |
| out-of-corpus | hallucinated | **refuses** |
| latency p50 | ~13s | **6.3s** |

## Notes
- **Merging triggers the Azure deploy**, which sets `FLASHCARD_MAX_RETRIEVAL_DISTANCE=0.65` live.
- 0.65 is tuned on a 10-case eval — worth watching prod for over-aggressive refusals; it's an env var, so it can be adjusted without rebuilding the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)