### PR TITLE
Drop unused judge_model key from faithfulness score result

### DIFF
--- a/backend/benchmarks/scorers/faithfulness.py
+++ b/backend/benchmarks/scorers/faithfulness.py
@@ -109,5 +109,4 @@ def score(record: dict, llm=None) -> dict | None:
     return {
         "faithfulness_mean": (sum(valid) / len(valid)) if valid else 0.0,
         "per_card": per_card,
-        "judge_model": os.getenv("RAGAS_JUDGE_MODEL", DEFAULT_JUDGE_MODEL),
     }


### PR DESCRIPTION
Removes the `judge_model` field returned by `benchmarks/scorers/faithfulness.py`'s `score()` — it was never consumed by `report.py` (which only reads `faithfulness_mean` and `per_card`).

One-line cleanup, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)